### PR TITLE
Use Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - name: Run tasks
         run: |
           npm ci
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use this action
         uses: ./
         id: assign

--- a/action.yml
+++ b/action.yml
@@ -38,5 +38,5 @@ outputs:
   result:
     description: '`success` or `failure` is set.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: ./. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

<img width="914" alt="Screenshot 2024-02-03 at 9 28 28" src="https://github.com/hkusu/review-assign-action/assets/5770480/a02e4cda-fafd-4e86-87b8-878664ada723">

The following results checked on my forked repository.

### Now
1 warning
https://github.com/ykws/review-assign-action/actions/runs/7762853217

### Use Node 20
No warning
https://github.com/ykws/review-assign-action/actions/runs/7762869419

If needed, upgrade dependencies on packages.